### PR TITLE
Dedup typedefs

### DIFF
--- a/Sources/Extraction/Filters/AbsoluteContrast.h
+++ b/Sources/Extraction/Filters/AbsoluteContrast.h
@@ -6,9 +6,6 @@
 #include "General/Array.h"
 #include "General/BinaryMap.h"
 
-typedef struct BinaryMap BinaryMap;
-
 void AbsoluteContrast_DetectLowContrast(const int limit, const UInt8Array2D *contrast, BinaryMap *output);
-
 
 #endif

--- a/Sources/Extraction/Filters/ClippedContrast.h
+++ b/Sources/Extraction/Filters/ClippedContrast.h
@@ -4,9 +4,9 @@
 #include <stdint.h>
 
 #include "General/Array.h"
+#include "General/BinaryMap.h"
 #include "General/BlockMap.h"
 
-typedef struct BinaryMap BinaryMap;
 typedef struct ClippedContrast ClippedContrast;
 
 struct ClippedContrast

--- a/Sources/Extraction/Filters/CrossRemover.h
+++ b/Sources/Extraction/Filters/CrossRemover.h
@@ -3,8 +3,6 @@
 
 #include "General/BinaryMap.h"
 
-typedef struct BinaryMap BinaryMap;
-
 void CrossRemover_Remove(BinaryMap *input);
 
 #endif

--- a/Sources/Extraction/Filters/VotingFilter.h
+++ b/Sources/Extraction/Filters/VotingFilter.h
@@ -2,8 +2,8 @@
 #define FILTERS_VOTINGFILTER_H
 
 #include <stdint.h>
+#include "General/BinaryMap.h"
 
-typedef struct BinaryMap BinaryMap;
 typedef struct VotingFilter VotingFilter;
 
 struct VotingFilter

--- a/Sources/General/BinaryMap.h
+++ b/Sources/General/BinaryMap.h
@@ -9,8 +9,6 @@
 #include "General/RectangleC.h"
 #include "General/Array.h"
 
-typedef struct Size Size;
-typedef struct RectangleC RectangleC;
 typedef struct BinaryMap BinaryMap;
 
 struct BinaryMap

--- a/Sources/General/Calc.h
+++ b/Sources/General/Calc.h
@@ -1,8 +1,8 @@
 #ifndef GENERAL_CALC_H
 #define GENERAL_CALC_H
 
-typedef struct Point Point;
-typedef struct PointF PointF;
+#include "General/Point.h"
+#include "General/PointF.h"
 
 int Calc_DivRoundUp(int input, int divider);
 int Calc_InterpolateFrom3Ints(int index, int count, int range);

--- a/Sources/General/Neighborhood.h
+++ b/Sources/General/Neighborhood.h
@@ -1,7 +1,8 @@
 #ifndef GENERAL_NEIGHBORHOOD_H
 #define GENERAL_NEIGHBORHOOD_H
 
-typedef struct Point Point;
+#include "General/Point.h"
+
 typedef struct Neighborhood Neighborhood;
 
 struct Neighborhood {

--- a/Sources/General/Point.h
+++ b/Sources/General/Point.h
@@ -4,12 +4,13 @@
 #include <stdbool.h>
 
 typedef struct Point Point;
-typedef struct Size Size;
 
 struct Point {
     int x;
     int y;
 };
+
+#include "General/Size.h"
 
 Point Point_Construct(int xx, int yy);
 int Point_GetHashCode(void);

--- a/Sources/General/PointF.h
+++ b/Sources/General/PointF.h
@@ -3,14 +3,16 @@
 
 #include <stdbool.h>
 
-typedef struct Point Point;
-typedef struct SizeF SizeF;
+#include "General/Point.h"
+
+
 typedef struct PointF PointF;
 
 struct PointF {
     float x;
     float y;
 };
+#include "General/SizeF.h"
 
 PointF PointF_Construct(float xx, float yy);
 PointF PointF_ConstructFromPoint(const Point *p);

--- a/Sources/General/RectangleC.h
+++ b/Sources/General/RectangleC.h
@@ -3,10 +3,11 @@
 
 #include <stdbool.h>
 
-typedef struct Point Point;
-typedef struct PointF PointF;
-typedef struct Size Size;
-typedef struct Range Range;
+#include "General/Point.h"
+#include "General/PointF.h"
+#include "General/Range.h"
+#include "General/Size.h"
+
 typedef struct RectangleC RectangleC;
 
 struct RectangleC {

--- a/Sources/General/Size.h
+++ b/Sources/General/Size.h
@@ -3,13 +3,14 @@
 
 #include <stdbool.h>
 
-typedef struct Point Point;
 typedef struct Size Size;
 
 struct Size {
     int width;
     int height;
 };
+
+#include "General/Point.h"
 
 Size Size_Construct(int w, int h);
 Size Size_ConstructFromPoint(const Point *p);

--- a/Sources/General/SizeF.h
+++ b/Sources/General/SizeF.h
@@ -1,13 +1,14 @@
 #ifndef GENERAL_SIZEF_H
 #define GENERAL_SIZEF_H
 
-typedef struct PointF PointF;
 typedef struct SizeF SizeF;
 
 struct SizeF {
     float width;
     float height;
 };
+
+#include "General/PointF.h"
 
 SizeF SizeF_Construct(float w, float h);
 SizeF SizeF_ConstructFromPointF(const PointF *p);


### PR DESCRIPTION
Cleaning up multiple typedef statements. Some of the includes look like they're in weird positions, but that's to stop circular references.
