### PR TITLE
Add implementation of fingerprint orientation

### DIFF
--- a/Sources/Extraction/Filters/HillOrientation.c
+++ b/Sources/Extraction/Filters/HillOrientation.c
@@ -1,26 +1,183 @@
 #include <stdlib.h>
 #include <assert.h>
+#include <math.h>
+#include <stdio.h>
 
 #include "HillOrientation.h"
+#include "General/Array.h"
 
-HillOrientation HillOrientation_Construct(void)
+#define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
+#define NUM_VECTORS (28)
+
+const Point neighbors[NUM_VECTORS] = {
+    { -1, 1, }, { -1, 2 }, { -1, 3 },
+    { -2, 1  }, { -2, 2 }, { -2, 3 },
+    { -3, 1  }, { -3, 2 }, { -3, 3 },
+    { 0, 1 }, { 0, 2, }, { 0, 3 },
+    { 1, 0 }, { 1, 1, }, { 1, 2 }, { 1, 3 },
+    { 2, 0 }, { 2, 1  }, { 2, 2 }, { 2, 3 },
+    { 3, 0 }, { 3, 1  }, { 3, 2 }, { 3, 3 },
+    { -5, 0 }, { -5, 5 }, { 0, 5 }, { 5, 5 }
+};
+
+static bool IsInsideImageAndMask(int imageHeight, int imageWidth, BoolArray2D pixelMask, int x, int y)
 {
-    HillOrientation ho = {
-        .minHalfDistance = 2,    /* Lower = 0.5, Upper = 4 */
-        .maxHalfDistance = 6,    /* Lower = 5, Upper = 13 */
-        .neighborListSplit = 50, /* Upper = 100 */
-        .neighborsChecked = 20,  /* Upper = 100 */
-        .smoothingRadius = 1     /* Upper = 3 */
-    };
+    bool ok = x >= 0
+        && y >= 0
+        && x < imageWidth
+        && y < imageHeight
+        && pixelMask.data[x][y];
 
-    return ho;
+    return ok;
 }
 
-void HillOrientation_Destruct(HillOrientation *me)
+/*
+static void print_directions(PointFArray2D directions) {
+  for ( int i=0; i < directions.sizeX; ++i ) {
+    for ( int j=0; j < directions.sizeY; ++j ) {
+      printf("(%f, %f)", directions.data[i][j].x, directions.data[i][j].y);
+    }
+    printf("\n");
+  }
+}
+*/
+
+/*
+static void print_BoolArray2D(BoolArray2D array) {
+  for ( int i=0; i < array.sizeX; ++i ) {
+    for ( int j=0; j < array.sizeY; ++j ) {
+      printf("%d ", array.data[i][j]);
+    }
+    printf("\n");
+  }
+} */
+
+PointFArray2D HillOrientation_AccumulateDirections(FloatArray2D input, int imageHeight, int imageWidth, BoolArray2D pixelMask)
 {
+    Size imageDimensions = (Size) { .height = imageHeight, .width = imageWidth };
+    PointFArray2D directions = PointFArray2D_Construct(imageDimensions.width, imageDimensions.height);
+
+    for (int x = 0; x < imageDimensions.width; x++)
+    {
+        for (int y = 0; y < imageDimensions.height; y++)
+        {
+            if(!pixelMask.data[x][y])
+                continue;
+
+            for (int i = 0; i < NUM_VECTORS; i++)
+            {
+                Point neighbor = Calc_Add2Points(&neighbors[i], &(Point) { .x = x, .y = y });
+                Point antiPoint = (Point) { .x = -neighbors[i].x, .y = -neighbors[i].y };
+                Point antiNeighbor = Calc_Add2Points(&antiPoint, &(Point) { .x = x, .y = y });
+
+                if(!IsInsideImageAndMask(imageHeight, imageWidth, pixelMask, neighbor.x, neighbor.y) || !IsInsideImageAndMask(imageHeight, imageWidth, pixelMask, antiNeighbor.x, antiNeighbor.y))
+                    continue;
+
+                float antiNeighborValue = input.data[antiNeighbor.x][antiNeighbor.y];
+                float pixelValue = input.data[x][y];
+                float neighborValue = input.data[neighbor.x][neighbor.y];
+
+                float strength = abs(pixelValue - MAX(neighborValue, antiNeighborValue));
+
+                PointF contribution = Calc_Scalar_Multiply(strength, neighbor);
+                directions.data[x][y] = Calc_Add2PointsF(&directions.data[x][y], &contribution);
+            }
+        }
+    }
+
+    //print_directions(directions);
+    return directions;
 }
 
-void /*UInt8Array2D*/ HillOrientation_Detect(const HillOrientation *me, const FloatArray2D *image, const BinaryMap *mask, const BlockMap *blocks)
+PointFArray2D HillOrientation_SumBlocks(const PointFArray2D * pixelOrientations, BinaryMap * blockMask, BlockMap * blocks)
 {
-    /* TODO: Implement HillOrientation_Detect() */
+    const PointFArray2D blockOrientations = PointFArray2D_Construct(blocks->blockCount.width, blocks->blockCount.height);
+    const int blockHeight = blocks->pixelCount.height / blocks->blockCount.height;
+    const int blockWidth = blocks->pixelCount.width / blocks->blockCount.width;
+
+    for (int blockX = 0; blockX < blocks->blockCount.width; blockX++)
+    {
+        for (int blockY = 0; blockY < blocks->blockCount.height; blockY++)
+        {
+            if (!BinaryMap_GetBit(blockMask, blockX, blockY))
+                continue;
+
+            int bottomLeftX = blocks->blockAreas.corners.allX.data[blockX];
+            int bottomLeftY = blocks->blockAreas.corners.allY.data[blockY];
+            for (int x = bottomLeftX; x < bottomLeftX + blockWidth; ++x) {
+                for ( int y = bottomLeftY; y < bottomLeftY + blockHeight; ++y ) {
+                    blockOrientations.data[blockX][blockY] = Calc_Add2PointsF(&blockOrientations.data[blockX][blockY], &pixelOrientations->data[x][y]);
+                }
+            }
+        }
+    }
+    return blockOrientations;
+}
+
+PointFArray2D HillOrientation_SmoothDirections(PointFArray2D directions, BinaryMap blockMask)
+{
+    // PointFArray2D smoothedDirections = PointFArray2D_Construct()
+    return  (PointFArray2D) { NULL };
+}
+
+BoolArray2D HillOrientation_BlockMapToPixelMask(Size imageDimensions, BinaryMap * blockMask, BlockMap * blocks) {
+    const int blockHeight = 15; //blocks->pixelCount.height / blocks->blockCount.height;
+    const int blockWidth = 15; //blocks->pixelCount.width / blocks->blockCount.width;
+
+    BoolArray2D pixelMask = BoolArray2D_Construct(imageDimensions.width, imageDimensions.height);
+
+    for (int blockX = 0; blockX < blocks->blockCount.width; blockX++)
+    {
+        for (int blockY = 0; blockY < blocks->blockCount.height; blockY++)
+        {
+            bool blockIsInImage = BinaryMap_GetBit(blockMask, blockX, blockY);
+            int bottomLeftX = blocks->blockAreas.corners.allX.data[blockX];
+            int bottomLeftY = blocks->blockAreas.corners.allY.data[blockY];
+            for (int x = bottomLeftX; x < bottomLeftX + blockWidth; ++x) {
+                for ( int y = bottomLeftY; y < bottomLeftY + blockHeight; ++y ) {
+                    pixelMask.data[x][y] = blockIsInImage;
+                }
+            }
+        }
+    }
+    return pixelMask;
+}
+
+PointFArray2D HillOrientation_Smooth(PointFArray2D directions, BinaryMap * mask)
+{
+    return (PointFArray2D) { NULL };
+}
+
+UInt16Array2D HillOrientation_DirectionsToAngles(PointFArray2D directions, BinaryMap *mask)
+{
+    UInt16Array2D angles = UInt16Array2D_Construct(mask->width, mask->height);
+
+    for(int x = 0; x < directions.sizeX; x++)
+    {
+        for(int y = 0; y < directions.sizeY; y++)
+        {
+            if(!BinaryMap_GetBit(mask, x, y))
+                continue;
+
+            double angle = atan2(directions.data[x][y].y, directions.data[x][y].x);
+            //multiply by 2 to collapse opposite angles onto each other
+            angles.data[x][y] = (uint16_t)(angle / 3.1415f * 360 * 2 + 90) % 360;
+        }
+    }
+
+    return angles;
+}
+
+UInt16Array2D HillOrientation_Detect(FloatArray2D image, Size imageDimensions, BinaryMap * blockMask, BlockMap * blocks)
+{
+    BoolArray2D pixelMask = HillOrientation_BlockMapToPixelMask(imageDimensions, blockMask, blocks);
+    PointFArray2D pixelDirections = HillOrientation_AccumulateDirections(image, imageDimensions.height, imageDimensions.width, pixelMask);
+    PointFArray2D blockDirections = HillOrientation_SumBlocks(&pixelDirections, blockMask, blocks);
+    UInt16Array2D angles = HillOrientation_DirectionsToAngles(blockDirections, blockMask);
+    //TODO smooth
+
+    PointFArray2D_Destruct(&pixelDirections);
+    //TODO free pixelMask
+    return angles;
 }

--- a/Sources/Extraction/Filters/HillOrientation.h
+++ b/Sources/Extraction/Filters/HillOrientation.h
@@ -8,27 +8,10 @@
 #include "General/PointF.h"
 #include "General/BlockMap.h"
 #include "General/BinaryMap.h"
+#include "General/List.h"
 
-typedef struct NeighborInfo NeighborInfo;
-typedef struct HillOrientation HillOrientation;
+UInt16Array2D HillOrientation_Detect(FloatArray2D image, Size imageDimensions, BinaryMap * blockMask, BlockMap * blocks);
+BoolArray2D HillOrientation_BlockMapToPixelMask(Size imageDimensions, BinaryMap * blockMask, BlockMap * blocks);
 
-struct NeighborInfo {
-    Point position;
-    PointF orientation;
-};
-
-struct HillOrientation
-{
-    float minHalfDistance;      /* Lower = 0.5, Upper = 4 */
-    float maxHalfDistance;      /* Lower = 5, Upper = 13 */
-    int32_t neighborListSplit;  /* Upper = 100 */
-    int32_t neighborsChecked;   /* Upper = 100 */
-    int32_t smoothingRadius;    /* Upper = 3 */
-    NeighborInfo neighborInfo;
-};
-
-HillOrientation HillOrientation_Construct(void);
-void HillOrientation_Destruct(HillOrientation *me);
-void /*UInt8Array2D*/ HillOrientation_Detect(const HillOrientation *me, const FloatArray2D *image, const BinaryMap *mask, const BlockMap *blocks);
 
 #endif

--- a/Sources/General/Array.c
+++ b/Sources/General/Array.c
@@ -100,6 +100,35 @@ bool* BoolArray1D_GetStorage(BoolArray1D *me)
     return &me->data[0];
 }
 
+BoolArray2D BoolArray2D_Construct(int32_t x, int32_t y)
+{
+    BoolArray2D array;
+
+    assert(x > 0 && y > 0);
+    array.sizeX = x;
+    array.sizeY = y;
+
+    array.data = calloc(x, sizeof(bool*));
+    assert(array.data);
+
+    array.data[0] = calloc(x * y, sizeof(bool));
+    assert(array.data[0]);
+
+    for (int i = 1; i < x; i++)
+        array.data[i] = array.data[0] + i * y;
+
+    return array;
+}
+
+void BoolArray2D_Destruct(BoolArray2D *me)
+{
+    free(me->data[0]);
+    free(me->data);
+    me->data = NULL;
+    me->sizeX = 0;
+    me->sizeY = 0;
+}
+
 UInt8Array2D UInt8Array2D_Construct(int32_t x, int32_t y)
 {
     UInt8Array2D array;
@@ -132,6 +161,35 @@ void UInt8Array2D_Destruct(UInt8Array2D *me)
 uint8_t* UInt8Array2D_GetStorage(UInt8Array2D *me)
 {
     return &me->data[0][0];
+}
+
+UInt16Array2D UInt16Array2D_Construct(int32_t x, int32_t y)
+{
+    UInt16Array2D array;
+
+    assert(x > 0 && y > 0);
+    array.sizeX = x;
+    array.sizeY = y;
+
+    array.data = calloc(x, sizeof(uint16_t*));
+    assert(array.data);
+
+    array.data[0] = calloc(x * y, sizeof(uint16_t));
+    assert(array.data[0]);
+
+    for (int i = 1; i < x; i++)
+        array.data[i] = array.data[0] + i * y;
+
+    return array;
+}
+
+void UInt16Array2D_Destruct(UInt16Array2D *me)
+{
+    free(me->data[0]);
+    free(me->data);
+    me->data = NULL;
+    me->sizeX = 0;
+    me->sizeY = 0;
 }
 
 UInt32Array2D UInt32Array2D_Construct(int32_t x, int32_t y)
@@ -362,4 +420,33 @@ void FloatArray3D_Destruct(FloatArray3D *me)
 float* FloatArray3D_GetStorage(FloatArray3D *me)
 {
     return &me->data[0][0][0];
+}
+
+PointFArray2D PointFArray2D_Construct(int32_t x, int32_t y)
+{
+    PointFArray2D array;
+
+    array.sizeX = x;
+    array.sizeY = y;
+
+    array.data = calloc(x, sizeof(PointF*));
+
+    for (int i = 0; i < x; i++)
+    {
+        array.data[i] = calloc(y, sizeof(PointF));
+    }
+
+    return array;
+}
+
+
+void PointFArray2D_Destruct(PointFArray2D *me)
+{
+    for(int i = 0; i < me->sizeX; i++){
+        free(me->data[i]);
+    }
+    free(me->data);
+    me->data = NULL;
+    me->sizeX = 0;
+    me->sizeY = 0;
 }

--- a/Sources/General/Array.h
+++ b/Sources/General/Array.h
@@ -5,20 +5,25 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "PointF.h"
 
 typedef struct Int32Array1D Int32Array1D;
 typedef struct UInt32Array1D UInt32Array1D;
 typedef struct FloatArray1D FloatArray1D;
 typedef struct BoolArray1D BoolArray1D;
 typedef struct PointArray1D PointArray1D;
+typedef struct BoolArray2D BoolArray2D;
 
 typedef struct UInt8Array2D UInt8Array2D;
+typedef struct UInt16Array2D UInt16Array2D;
 typedef struct UInt32Array2D UInt32Array2D;
 typedef struct FloatArray2D FloatArray2D;
 typedef struct PointArray2D PointArray2D;
 
 typedef struct Int16Array3D Int16Array3D;
 typedef struct FloatArray3D FloatArray3D;
+
+typedef struct PointFArray2D PointFArray2D;
 
 struct Int32Array1D
 {
@@ -44,9 +49,23 @@ struct BoolArray1D
     int32_t size;
 };
 
+struct BoolArray2D
+{
+    bool **data;
+    int32_t sizeX;
+    int32_t sizeY;
+};
+
 struct UInt8Array2D
 {
     uint8_t **data;
+    int32_t sizeX;
+    int32_t sizeY;
+};
+
+struct UInt16Array2D
+{
+    uint16_t **data;
     int32_t sizeX;
     int32_t sizeY;
 };
@@ -93,6 +112,13 @@ struct FloatArray3D
     int32_t sizeZ;
 };
 
+struct PointFArray2D
+{
+    PointF **data;
+    int32_t sizeX;
+    int32_t sizeY;
+};
+
 Int32Array1D Int32Array1D_Construct(int32_t x);
 void Int32Array1D_Destruct(Int32Array1D *me);
 int32_t* Int32Array1D_GetStorage(Int32Array1D *me);
@@ -105,9 +131,15 @@ FloatArray1D FloatArray1D_Construct(int32_t x);
 void FloatArray1D_Destruct(FloatArray1D *me);
 float* FloatArray1D_GetStorage(FloatArray1D *me);
 
+BoolArray2D BoolArray2D_Construct(int32_t x, int32_t y);
+void BoolArray2D_Destruct(BoolArray2D *me);
+
 UInt8Array2D UInt8Array2D_Construct(int32_t x, int32_t y);
 void UInt8Array2D_Destruct(UInt8Array2D *me);
 uint8_t* UInt8Array2D_GetStorage(UInt8Array2D *me);
+
+UInt16Array2D UInt16Array2D_Construct(int32_t x, int32_t y);
+void UInt16Array2D_Destruct(UInt16Array2D *me);
 
 UInt32Array2D UInt32Array2D_Construct(int32_t x, int32_t y);
 void UInt32Array2D_Destruct(UInt32Array2D *me);
@@ -134,5 +166,8 @@ int16_t* Int16Array3D_GetStorage(Int16Array3D *me);
 FloatArray3D FloatArray3D_Construct(int32_t x, int32_t y, int32_t z);
 void FloatArray3D_Destruct(FloatArray3D *me);
 float* FloatArray3D_GetStorage(FloatArray3D *me);
+
+PointFArray2D PointFArray2D_Construct(int32_t x, int32_t y);
+void PointFArray2D_Destruct(PointFArray2D *me);
 
 #endif

--- a/Sources/General/Calc.c
+++ b/Sources/General/Calc.c
@@ -2,6 +2,7 @@
 #include "General/PointF.h"
 #include "General/Size.h"
 #include "General/Calc.h"
+#include "General/SizeF.h"
 
 int Calc_DivRoundUp(int input, int divider)
 {
@@ -17,6 +18,11 @@ Point Calc_Add2Points(const Point *p1, const Point *p2)
 {
     Size s = Size_ConstructFromPoint(p2);
     return Point_AddSize(p1, &s);
+}
+
+PointF Calc_Add2PointsF(const PointF *p1, const PointF *p2) {
+  SizeF s = SizeF_ConstructFromPointF(p2);
+  return PointF_AddSizeF(p1, &s);
 }
 
 PointF Calc_Scalar_Multiply(float scalar, Point p) {

--- a/Sources/General/Calc.c
+++ b/Sources/General/Calc.c
@@ -19,6 +19,10 @@ Point Calc_Add2Points(const Point *p1, const Point *p2)
     return Point_AddSize(p1, &s);
 }
 
+PointF Calc_Scalar_Multiply(float scalar, Point p) {
+  return (PointF) { .x = scalar * p.x, .y = scalar * p.y };
+}
+
 float Calc_InterpolateFrom3Floats(float value0, float value1, float fraction)
 {
     return value0 + fraction * (value1 - value0);

--- a/Sources/General/Calc.h
+++ b/Sources/General/Calc.h
@@ -9,5 +9,6 @@ int Calc_InterpolateFrom3Ints(int index, int count, int range);
 Point Calc_Add2Points(const Point *p1, const Point *p2);
 float Calc_InterpolateFrom3Floats(float value0, float value1, float fraction);
 float Calc_InterpolateRect(float topLeft, float topRight, float bottomLeft, float bottomRight, const PointF *fraction);
+PointF Calc_Scalar_Multiply(float scalar, Point p1);
 
 #endif

--- a/Sources/General/Calc.h
+++ b/Sources/General/Calc.h
@@ -9,6 +9,7 @@ int Calc_InterpolateFrom3Ints(int index, int count, int range);
 Point Calc_Add2Points(const Point *p1, const Point *p2);
 float Calc_InterpolateFrom3Floats(float value0, float value1, float fraction);
 float Calc_InterpolateRect(float topLeft, float topRight, float bottomLeft, float bottomRight, const PointF *fraction);
+PointF Calc_Add2PointsF(const PointF *p1, const PointF *p2);
 PointF Calc_Scalar_Multiply(float scalar, Point p1);
 
 #endif

--- a/Sources/Makefile
+++ b/Sources/Makefile
@@ -95,7 +95,7 @@ $(BUILD_DIR)/%.o: %.c
 	$(CC) -c $(COMMON_CFLAGS) $(LIBAFIS_CFLAGS) $(LIBAFIS_INCS) $< -o $@
 
 $(BUILD_DIR)/Tests/extract: $(BUILD_DIR)/Tests/extract.o $(LIBAFIS_OBJS)
-	$(CC) $(LFLAGS) $^ -o $@
+	$(CC) $^ $(LFLAGS) -o $@
 
 $(UTILS_OBJS): $(BUILD_DIR)/%.o: %.c
 	@$(MKDIR) $(@D)
@@ -110,7 +110,7 @@ $(UNITY_OBJS):  $(BUILD_DIR)/%.o: %.c
 	$(CC) -c $(COMMON_CFLAGS) $(UNITY_CFLAGS) $(UNITY_INCS) $< -o $@
 
 $(UTEST_EXE): $(UTEST_OBJS) $(UNITY_OBJS) $(UTILS_OBJS) $(LIBAFIS_OBJS)
-	$(CC) $(LFLAGS) $^ -o $(BUILD_DIR)/$@
+	$(CC) $^ $(LFLAGS) -o $(BUILD_DIR)/$@
 
 runUnitTest: $(UTEST_EXE)
 	$(BUILD_DIR)/all_tests ../TestData/

--- a/Sources/Makefile
+++ b/Sources/Makefile
@@ -20,7 +20,7 @@ UNITY_CFLAGS = -Wall -Wextra -Werror -Wpointer-arith -Wcast-align -Wwrite-string
 ##
 ## Linker flags
 ##
-LFLAGS = -g
+LFLAGS = -g -lm
 
 ##
 ## Root directories

--- a/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
+++ b/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
@@ -1,0 +1,135 @@
+#include "Extraction/Filters/HillOrientation.h"
+#include "Extraction/Filters/LocalHistogram.h"
+#include "Extraction/Filters/SegmentationMask.h"
+#include "Extraction/Filters/Equalizer.h"
+#include "General/pgm.h"
+#include "unity.h"
+#include "unity_fixture.h"
+#include <stdio.h>
+
+TEST_GROUP(HillOrientation);
+
+TEST_SETUP(HillOrientation)
+{
+}
+
+TEST_TEAR_DOWN(HillOrientation)
+{
+}
+
+static void print_orientations(UInt16Array2D orientations) {
+  for ( int i=0; i < orientations.sizeX; ++i ) {
+    for ( int j=0; j < orientations.sizeY; ++j ) {
+      printf("%d ", orientations.data[i][j]);
+    }
+    printf("\n");
+  }
+}
+
+TEST(HillOrientation, VisualiseOrientations)
+{
+  UInt8Array2D v = pgm_read("../TestImages/Person1/Bas1440999265-Hamster-0-1.png.pgm");
+
+  Size imgSize = {.width = v.sizeX, .height = v.sizeY};
+  BlockMap blocks = BlockMap_Construct(&imgSize, 15);
+
+  Int16Array3D histogram = Int16Array3D_Construct(blocks.blockCount.width, blocks.blockCount.height, 256);
+  Int16Array3D smoothedHistogram = Int16Array3D_Construct(blocks.cornerCount.width, blocks.cornerCount.height, 256);
+
+  LocalHistogram_Analyze(&blocks, &v, &histogram);
+  LocalHistogram_SmoothAroundCorners(&histogram, &smoothedHistogram);
+
+  BinaryMap mask = BinaryMap_Construct(blocks.blockCount.width, blocks.blockCount.height);
+
+  SegmentationMask sm = SegmentationMask_Construct();
+  SegmentationMask_ComputeMask(&sm, &blocks, &histogram, &mask);
+
+
+  FloatArray2D equalized = FloatArray2D_Construct(v.sizeX, v.sizeY);
+  Equalizer eq = Equalizer_Construct();
+  Equalizer_Equalize(&eq, &blocks, &v, &smoothedHistogram, &mask, &equalized);
+
+  UInt16Array2D orientations = HillOrientation_Detect(equalized, imgSize, &mask, &blocks);
+
+  print_orientations(orientations);
+  UInt8Array2D outV = UInt8Array2D_Construct(imgSize.width, imgSize.height);
+  for ( int i=0; i < orientations.sizeX; ++i ) {
+    for ( int j=0; j < orientations.sizeY; ++j ) {
+      int centerX = blocks.blockCenters.allX.data[i];
+      int centerY = blocks.blockCenters.allY.data[j];
+      outV.data[centerX][centerY] = 255;
+
+      if((orientations.data[i][j] + 360/16) % 360 < 360/8)
+      {
+        outV.data[centerX+1][centerY] = 255;
+        outV.data[centerX+2][centerY] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 2*360/8)
+      {
+        outV.data[centerX+1][centerY+1] = 255;
+        outV.data[centerX+2][centerY+2] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 3*360/8)
+      {
+        outV.data[centerX][centerY+1] = 255;
+        outV.data[centerX][centerY+2] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 4*360/8)
+      {
+        outV.data[centerX-1][centerY+1] = 255;
+        outV.data[centerX-2][centerY+2] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 5*360/8)
+      {
+        outV.data[centerX-1][centerY] = 255;
+        outV.data[centerX-2][centerY] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 6*360/8)
+      {
+        outV.data[centerX-1][centerY-1] = 255;
+        outV.data[centerX-2][centerY-2] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 7*360/8)
+      {
+        outV.data[centerX][centerY-1] = 255;
+        outV.data[centerX][centerY-2] = 255;
+      }
+      else if((orientations.data[i][j] + 360/16) % 360 < 8*360/8)
+      {
+        outV.data[centerX+1][centerY-1] = 255;
+        outV.data[centerX+2][centerY-2] = 255;
+      }
+
+    }
+  }
+  pgm_write("../TestImages/Person1/output-Hamster-0.1.pgm", &outV);
+}
+
+TEST(HillOrientation, VisualisePixelMask)
+{
+  UInt8Array2D v = pgm_read("../TestImages/Person1/Bas1440999265-Hamster-1-0.png.pgm");
+
+  Size imgSize = {.width = v.sizeX, .height = v.sizeY};
+  BlockMap blocks = BlockMap_Construct(&imgSize, 15);
+
+  Int16Array3D histogram = Int16Array3D_Construct(blocks.blockCount.width, blocks.blockCount.height, 256);
+  Int16Array3D smoothedHistogram = Int16Array3D_Construct(blocks.cornerCount.width, blocks.cornerCount.height, 256);
+
+  LocalHistogram_Analyze(&blocks, &v, &histogram);
+  LocalHistogram_SmoothAroundCorners(&histogram, &smoothedHistogram);
+
+  BinaryMap mask = BinaryMap_Construct(blocks.blockCount.width, blocks.blockCount.height);
+
+  SegmentationMask sm = SegmentationMask_Construct();
+  SegmentationMask_ComputeMask(&sm, &blocks, &histogram, &mask);
+
+  BoolArray2D pixelMask = HillOrientation_BlockMapToPixelMask(imgSize, &mask, &blocks);
+
+  UInt8Array2D outV = UInt8Array2D_Construct(imgSize.width, imgSize.height);
+  for ( int i=0; i < pixelMask.sizeX; ++i ) {
+    for ( int j=0; j < pixelMask.sizeY; ++j ) {
+      outV.data[i][j] = pixelMask.data[i][j] ? 255 : 0;
+    }
+  }
+  pgm_write("../TestImages/Person1/output-Hamster-0.1-pixelmask.pgm", &outV);
+}

--- a/Sources/Tests/Extraction/Filters/runners/TestRunner_HillOrientation.c
+++ b/Sources/Tests/Extraction/Filters/runners/TestRunner_HillOrientation.c
@@ -1,0 +1,8 @@
+#include "unity.h"
+#include "unity_fixture.h"
+
+TEST_GROUP_RUNNER(HillOrientation)
+{
+    RUN_TEST_CASE(HillOrientation, VisualiseOrientations);
+    RUN_TEST_CASE(HillOrientation, VisualisePixelMask);
+}

--- a/Sources/Tests/all_tests.c
+++ b/Sources/Tests/all_tests.c
@@ -25,6 +25,9 @@ static void RunAllTests(void)
     printf("\nEnsure we an load serialised binary data\n");
     RUN_TEST_GROUP(DataStructures);
 
+    printf("\nOrientation tests\n");
+    RUN_TEST_GROUP(HillOrientation);
+
     printf("\nEqualizer tests\n");
     RUN_TEST_GROUP(Equalizer); 
 }


### PR DESCRIPTION
This PR contains the implementation of the orientation step, and some associated new data structures and tests.

SourceAFIS uses a random(ish) sampling of neighbours but we're using a hard coded set, the same for each pixel. We're not sure how much impact that has on the result.

Currently, the smoothing step of orientation is not performed. The results don't look fantastic but it's also a bit hard to tell with the current visualisation.
