### PR TITLE
Fix memory errors

### DIFF
--- a/Sources/Extraction/Extract.c
+++ b/Sources/Extraction/Extract.c
@@ -48,4 +48,10 @@ void Extract(UInt8Array2D *image, struct perfdata *perfdata)
     if (perfdata) gettimeofday(&perfdata->start_filtering, 0);
 
     if (perfdata) gettimeofday(&perfdata->end, 0);
+
+    BlockMap_Destruct(&blocks);
+    Int16Array3D_Destruct(&histogram);
+    Int16Array3D_Destruct(&smoothHistogram);
+    BinaryMap_Destruct(&mask);
+    Equalizer_Destruct(&eq);
 }

--- a/Sources/General/Array.c
+++ b/Sources/General/Array.c
@@ -259,6 +259,7 @@ void PointArray2D_Destruct(PointArray2D *me)
 {
     for (int row = 0; row < me->size; row++)
     {
+        PointArray1D_Destruct(me->data[row]);
         free(me->data[row]);
     }
     free(me->data);

--- a/Sources/General/Array.c
+++ b/Sources/General/Array.c
@@ -176,10 +176,10 @@ FloatArray2D FloatArray2D_Construct(int32_t x, int32_t y)
     array.sizeX = x;
     array.sizeY = y;
 
-    array.data = calloc(x, sizeof(uint32_t*));
+    array.data = calloc(x, sizeof(float*));
     assert(array.data);
 
-    array.data[0] = calloc(x * y, sizeof(uint32_t));
+    array.data[0] = calloc(x * y, sizeof(float));
     assert(array.data[0]);
 
     for (int i = 1; i < x; i++)
@@ -234,7 +234,7 @@ PointArray2D PointArray2D_Construct(int32_t x)
     assert(x > 0 );
     array.size = x;
 
-    array.data = calloc(x, sizeof(uint32_t*));
+    array.data = calloc(x, sizeof(PointArray1D*));
     assert(array.data);
 
     return array;
@@ -243,9 +243,9 @@ PointArray2D PointArray2D_Construct(int32_t x)
 PointArray1D* PointArray2D_ConstructRow(PointArray2D *me, int rowId, int32_t x)
 {
     PointArray1D *array = PointArray1D_Construct(x);
-    
+
     me->data[rowId] = array;
-    
+
     return array;
 }
 

--- a/Sources/General/BlockMap.c
+++ b/Sources/General/BlockMap.c
@@ -109,6 +109,22 @@ static RectangleGrid InitCornerAreas(const BlockMap *me)
     return RectangleGrid_Construct(&grid);
 }
 
+static RectangleGrid InitBlockAreas(const PointGrid *c)
+{
+  RectangleGrid rg;
+
+  rg.corners.allX =  Int32Array1D_Construct(c->allX.size);
+  rg.corners.allY =  Int32Array1D_Construct(c->allY.size);
+  for(int i = 0; i < c->allX.size; i++){
+    rg.corners.allX.data[i] = c->allX.data[i];
+  }
+  for(int i = 0; i < c->allY.size; i++){
+    rg.corners.allY.data[i] = c->allY.data[i];
+  }
+
+  return rg;
+}
+
 BlockMap BlockMap_Construct(const Size *pixelSize, int maxBlockSize)
 {
     BlockMap bm;
@@ -120,7 +136,7 @@ BlockMap BlockMap_Construct(const Size *pixelSize, int maxBlockSize)
     bm.allBlocks = RectangleC_ConstructFromSize(&bm.blockCount);
     bm.allCorners = RectangleC_ConstructFromSize(&bm.cornerCount);
     bm.corners = InitCorners(&bm);
-    bm.blockAreas = RectangleGrid_Construct(&bm.corners);
+    bm.blockAreas = InitBlockAreas(&bm.corners);
     bm.blockCenters = InitBlockCenters(&bm);
     bm.cornerAreas = InitCornerAreas(&bm);
     return bm;
@@ -129,7 +145,7 @@ BlockMap BlockMap_Construct(const Size *pixelSize, int maxBlockSize)
 void BlockMap_Destruct(BlockMap *me)
 {
     PointGrid_Destruct(&me->corners);
-    //PointGrid_Destruct(&me->blockAreas.corners);
+    PointGrid_Destruct(&me->blockAreas.corners);
     PointGrid_Destruct(&me->blockCenters);
     PointGrid_Destruct(&me->cornerAreas.corners);
 }

--- a/Sources/Tests/DataStructures/Test_DataStructures.c
+++ b/Sources/Tests/DataStructures/Test_DataStructures.c
@@ -31,6 +31,7 @@ TEST(DataStructures, BlockMap_SanityCheck)
     {
         BlockMapIO_Printf(&blockMap);
     }
+    BlockMap_Destruct(&blockMap);
 }
 
 TEST(DataStructures, Image_SanityCheck)
@@ -40,6 +41,7 @@ TEST(DataStructures, Image_SanityCheck)
     {
         ImageIO_Printf(&image);
     }
+    UInt8Array2D_Destruct(&image);
 }
 
 TEST(DataStructures, Histogram_SanityCheck)
@@ -49,6 +51,7 @@ TEST(DataStructures, Histogram_SanityCheck)
     {
         HistogramIO_Printf(&histogram);
     }
+    Int16Array3D_Destruct(&histogram);
 }
 
 TEST(DataStructures, TwoDFloatArray_SanityCheck)
@@ -58,24 +61,26 @@ TEST(DataStructures, TwoDFloatArray_SanityCheck)
     {
         ArrayIO_FloatArray2D_Printf(&array);
     }
+    FloatArray2D_Destruct(&array);
 }
 
-TEST(DataStructures, TwoDByteArray_SanityCheck) 
+TEST(DataStructures, TwoDByteArray_SanityCheck)
 {
     UInt8Array2D array = ArrayIO_UInt8Array2D_ConstructFromFile("DataStructures/101_1.tif.4.ClippedContrast.result.dat");
     if (OutputDebug)
     {
         ArrayIO_UInt8Array2D_Printf(&array);
     }
+    UInt8Array2D_Destruct(&array);
 }
 
-TEST(DataStructures, Int_SanityCheck) 
+TEST(DataStructures, Int_SanityCheck)
 {
     int32_t  value = Int32_ConstructFromFile("DataStructures/101_1.tif.5.AbsoluteContrast.Limit.dat");
     assert(value == 17);
 }
 
-TEST(DataStructures, Float_SanityCheck) 
+TEST(DataStructures, Float_SanityCheck)
 {
     float value = Float_ConstructFromFile("DataStructures/101_1.tif.15.LinesByOrientation.StepFactor.dat");
     float valueToLookFor = 1.59f;
@@ -89,4 +94,5 @@ TEST(DataStructures, Two2PointArray_SanityCheck)
     {
         ArrayIO_PointArray2D_Printf(&array);
     }
+    PointArray2D_Destruct(&array);
 }

--- a/Sources/Tests/Extraction/Filters/Test_LocalHistogram.c
+++ b/Sources/Tests/Extraction/Filters/Test_LocalHistogram.c
@@ -40,6 +40,7 @@ TEST(LocalHistogram, LocalHistogram_Analyze_same_values_go_into_same_bucket)
     TEST_ASSERT_EQUAL_INT(2, histogram.data[0][0][3]);
 
     UInt8Array2D_Destruct(&image);
+    BlockMap_Destruct(&blocks);
     Int16Array3D_Destruct(&histogram);
 }
 
@@ -61,6 +62,7 @@ TEST(LocalHistogram, LocalHistogram_Analyze_different_values_go_into_different_b
     TEST_ASSERT_EQUAL_INT(1, histogram.data[0][0][4]);
 
     UInt8Array2D_Destruct(&image);
+    BlockMap_Destruct(&blocks);
     Int16Array3D_Destruct(&histogram);
 }
 
@@ -82,6 +84,7 @@ TEST(LocalHistogram, LocalHistogram_Analyze_multiple_blocks)
     TEST_ASSERT_EQUAL_INT(0, histogram.data[1][0][1]);
     TEST_ASSERT_EQUAL_INT(0, histogram.data[1][1][1]);
 
+    BlockMap_Destruct(&blocks);
     UInt8Array2D_Destruct(&image);
     Int16Array3D_Destruct(&histogram);
 }

--- a/Sources/Tests/General/Test_BinaryMap.c
+++ b/Sources/Tests/General/Test_BinaryMap.c
@@ -51,6 +51,9 @@ TEST(BinaryMap, BinaryMap_And)
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, BinaryMap_GetBit(&source,0,2), "Failed at: 0,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, BinaryMap_GetBit(&source,1,2), "Failed at: 1,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, BinaryMap_GetBit(&source,2,2), "Failed at: 2,2");
+
+    BinaryMap_Destruct(&source);
+    BinaryMap_Destruct(&target);
 }
 
 TEST(BinaryMap, BinaryMap_Or)
@@ -91,6 +94,9 @@ TEST(BinaryMap, BinaryMap_Or)
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,0,2), "Failed at: 0,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,1,2), "Failed at: 1,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,2,2), "Failed at: 2,2");
+
+    BinaryMap_Destruct(&source);
+    BinaryMap_Destruct(&target);
 }
 
 TEST(BinaryMap, BinaryMap_AndNot)
@@ -130,6 +136,9 @@ TEST(BinaryMap, BinaryMap_AndNot)
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,0,2), "Failed at: 0,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,1,2), "Failed at: 1,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,2,2), "Failed at: 2,2");
+
+    BinaryMap_Destruct(&source);
+    BinaryMap_Destruct(&target);
 }
 
 TEST(BinaryMap, BinaryMap_AndArea)
@@ -174,4 +183,7 @@ TEST(BinaryMap, BinaryMap_AndArea)
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,0,2), "Failed at: 0,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,1,2), "Failed at: 1,2");
     TEST_ASSERT_EQUAL_INT_MESSAGE(1, BinaryMap_GetBit(&source,2,2), "Failed at: 2,2");
+
+    BinaryMap_Destruct(&source);
+    BinaryMap_Destruct(&target);
 }

--- a/Sources/Tests/General/Test_Equalizer.c
+++ b/Sources/Tests/General/Test_Equalizer.c
@@ -22,13 +22,13 @@ TEST_TEAR_DOWN(Equalizer)
 
 TEST(Equalizer, Equalizer_Equals_SourceAFIS_Output_3x3)
 {
-    UInt8Array2D v = UInt8Array2D_Construct(3, 3); 
+    UInt8Array2D v = UInt8Array2D_Construct(3, 3);
 
     uint8_t imgData[][3] = {{1, 255, 1}, {255, 120, 240}, {3, 5, 19}};
 
     for (int i = 0; i < v.sizeX; i++) {
         for (int j = 0; j < v.sizeY; j++) {
-            v.data[i][j] = imgData[i][j]; 
+            v.data[i][j] = imgData[i][j];
         }
     }
 
@@ -38,28 +38,35 @@ TEST(Equalizer, Equalizer_Equals_SourceAFIS_Output_3x3)
     Int16Array3D histogram = Int16Array3D_Construct(blocks.blockCount.width, blocks.blockCount.height, 256);
     Int16Array3D smoothedHistogram = Int16Array3D_Construct(blocks.cornerCount.width, blocks.cornerCount.height, 256);
 
-    LocalHistogram_Analyze(&blocks, &v, &histogram); 
-    LocalHistogram_SmoothAroundCorners(&histogram, &smoothedHistogram); 
+    LocalHistogram_Analyze(&blocks, &v, &histogram);
+    LocalHistogram_SmoothAroundCorners(&histogram, &smoothedHistogram);
 
-    BinaryMap mask = BinaryMap_Construct(blocks.blockCount.width, blocks.blockCount.height); 
+    BinaryMap mask = BinaryMap_Construct(blocks.blockCount.width, blocks.blockCount.height);
 
-    SegmentationMask sm = SegmentationMask_Construct(); 
-    SegmentationMask_ComputeMask(&sm, &blocks, &histogram, &mask);   
+    SegmentationMask sm = SegmentationMask_Construct();
+    SegmentationMask_ComputeMask(&sm, &blocks, &histogram, &mask);
 
 
-    FloatArray2D equalized = FloatArray2D_Construct(v.sizeX, v.sizeY); 
+    FloatArray2D equalized = FloatArray2D_Construct(v.sizeX, v.sizeY);
     Equalizer eq = Equalizer_Construct();
     Equalizer_Equalize(&eq, &blocks, &v, &smoothedHistogram, &mask, &equalized);
 
     float expected[][3] = {{-0.998047, 1.0, -0.998047}, {1.0, 0.21568623, 0.542484}, {-0.90648437, -0.84414065, -0.4077344}};
 
-    const float EPSILON = 1e-6F; 
-    char assertMessage[100];
+    const float EPSILON = 1e-6F;
+    char assertMessage[256];
     for (int i = 0; i < equalized.sizeX; i++) {
         for (int j = 0; j < equalized.sizeY; j++) {
              sprintf(assertMessage, "[%d][%d] expected:, %f, actual: %f", i, j, expected[i][j], equalized.data[i][j]);
              TEST_ASSERT_MESSAGE(fabs(expected[i][j] - equalized.data[i][j]) < EPSILON, assertMessage);
         }
     }
-}
 
+    UInt8Array2D_Destruct(&v);
+    BlockMap_Destruct(&blocks);
+    Int16Array3D_Destruct(&histogram);
+    Int16Array3D_Destruct(&smoothedHistogram);
+    BinaryMap_Destruct(&mask);
+    FloatArray2D_Destruct(&equalized);
+    Equalizer_Destruct(&eq);
+}

--- a/Sources/Tests/General/Test_Equalizer.c
+++ b/Sources/Tests/General/Test_Equalizer.c
@@ -54,7 +54,7 @@ TEST(Equalizer, Equalizer_Equals_SourceAFIS_Output_3x3)
     float expected[][3] = {{-0.998047, 1.0, -0.998047}, {1.0, 0.21568623, 0.542484}, {-0.90648437, -0.84414065, -0.4077344}};
 
     const float EPSILON = 1e-6F;
-    char assertMessage[256];
+    char assertMessage[100];
     for (int i = 0; i < equalized.sizeX; i++) {
         for (int j = 0; j < equalized.sizeY; j++) {
              sprintf(assertMessage, "[%d][%d] expected:, %f, actual: %f", i, j, expected[i][j], equalized.data[i][j]);

--- a/Sources/Tests/General/Test_Pgm.c
+++ b/Sources/Tests/General/Test_Pgm.c
@@ -22,13 +22,13 @@ TEST_TEAR_DOWN(Pgm)
 TEST(Pgm, Pgm_Read)
 {
     UInt8Array2D v = pgm_read("../TestImages/Person1/Bas1440999265-Hamster-0-1.png.pgm");
-    /*UInt8Array2D v = UInt8Array2D_Construct(3, 3); 
+    /*UInt8Array2D v = UInt8Array2D_Construct(3, 3);
 
     uint8_t imgData[][3] = {{1, 255, 1}, {255, 120, 240}, {3, 5, 19}};
 
     for (int i = 0; i < v.sizeX; i++) {
         for (int j = 0; j < v.sizeY; j++) {
-            v.data[i][j] = imgData[i][j]; 
+            v.data[i][j] = imgData[i][j];
         }
     }*/
 
@@ -38,33 +38,35 @@ TEST(Pgm, Pgm_Read)
     Int16Array3D histogram = Int16Array3D_Construct(blocks.blockCount.width, blocks.blockCount.height, 256);
     Int16Array3D smoothedHistogram = Int16Array3D_Construct(blocks.cornerCount.width, blocks.cornerCount.height, 256);
 
-    LocalHistogram_Analyze(&blocks, &v, &histogram); 
-    LocalHistogram_SmoothAroundCorners(&histogram, &smoothedHistogram); 
+    LocalHistogram_Analyze(&blocks, &v, &histogram);
+    LocalHistogram_SmoothAroundCorners(&histogram, &smoothedHistogram);
 
-    BinaryMap mask = BinaryMap_Construct(blocks.blockCount.width, blocks.blockCount.height); 
+    BinaryMap mask = BinaryMap_Construct(blocks.blockCount.width, blocks.blockCount.height);
 
-    SegmentationMask sm = SegmentationMask_Construct(); 
-    SegmentationMask_ComputeMask(&sm, &blocks, &histogram, &mask);   
+    SegmentationMask sm = SegmentationMask_Construct();
+    SegmentationMask_ComputeMask(&sm, &blocks, &histogram, &mask);
 
 
-    FloatArray2D equalized = FloatArray2D_Construct(v.sizeX, v.sizeY); 
+    FloatArray2D equalized = FloatArray2D_Construct(v.sizeX, v.sizeY);
     Equalizer eq = Equalizer_Construct();
     Equalizer_Equalize(&eq, &blocks, &v, &smoothedHistogram, &mask, &equalized);
 
 
-    UInt8Array2D newV = UInt8Array2D_Construct(equalized.sizeX, equalized.sizeY); 
+    UInt8Array2D newV = UInt8Array2D_Construct(equalized.sizeX, equalized.sizeY);
     for (int i = 0; i < equalized.sizeX; i++) {
         for (int j = 0; j < equalized.sizeY; j++) {
-            newV.data[i][j] = (equalized.data[i][j] + 1.0) * 127.0; 
+            newV.data[i][j] = (equalized.data[i][j] + 1.0) * 127.0;
         }
     }
 
     pgm_write("../TestImages/Person1/output-Hamster-0.1.pgm", &newV);
 
+    BlockMap_Destruct(&blocks);
     UInt8Array2D_Destruct(&v);
     UInt8Array2D_Destruct(&newV);
     BinaryMap_Destruct(&mask);
+    FloatArray2D_Destruct(&equalized);
+    Equalizer_Destruct(&eq);
     Int16Array3D_Destruct(&histogram);
     Int16Array3D_Destruct(&smoothedHistogram);
-    BlockMap_Destruct(&blocks);
 }

--- a/Sources/Tests/Matcher/Test_BestMatchSkipper.c
+++ b/Sources/Tests/Matcher/Test_BestMatchSkipper.c
@@ -27,11 +27,12 @@ TEST(BestMatchSkipper, BestMatchSkipper_Scores)
 {
   BestMatchSkipper b = BestMatchSkipper_Construct(3,2);
   float skipScore;
-  
+
   BestMatchSkipper_AddScore(&b, 0,1.1);
   BestMatchSkipper_AddScore(&b, 1,1.2);
   BestMatchSkipper_AddScore(&b, 2,1.4);
 
   skipScore = BestMatchSkipper_GetSkipScore(&b, 2);
   TEST_ASSERT_EQUAL_FLOAT_MESSAGE(1.4, skipScore, "Skip score");
+  BestMatchSkipper_Destruct(&b);
 }


### PR DESCRIPTION
This PR fixes the memory leaks identified by using `valgrind` on the Unity tests, as well as incorrect allocation types for some arrays.

Originally, the output of `valgrind` running on the tests reported:

```
definitely lost: 16,908 bytes
indirectly lost: 1,990,281 bytes
```

The changes in this PR now reduces them to:

```
definitely lost: 80 bytes
indirectly lost: 68 bytes
```

These final lost bytes are to do with `sprintf` and a memory leak in the `UnityPrint` function in Unity. I'll continue to have a look at these.
