### PR TITLE
Fix mem leaks

### DIFF
--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -109,9 +109,9 @@ static List TraceRidge(Point point, Point prev, BinaryMap * image, List outputPo
   return outputPoints;
 }
 
-static Minutia * GetMinutiaAtPosition(Point position, List minutiae)
+static Minutia * GetMinutiaAtPosition(Point position, List* minutiae)
 {
-  for ( ListElement * p = minutiae.head; p != NULL; p = p->next )
+  for ( ListElement * p = minutiae->head; p != NULL; p = p->next )
   {
     Minutia * minutia = (Minutia *)p->data;
     if(minutia->position.x == position.x && minutia->position.y == position.y)
@@ -120,9 +120,9 @@ static Minutia * GetMinutiaAtPosition(Point position, List minutiae)
   return NULL;
 }
 
-static void TraceRidges(List minutiae, BinaryMap * image)
+static void TraceRidges(List* minutiae, BinaryMap * image)
 {
-  for ( ListElement * p = minutiae.head; p != NULL; p = p->next )
+  for ( ListElement * p = minutiae->head; p != NULL; p = p->next )
   {
     Minutia * minutia = (Minutia *)p->data;
     List activeNeighbors = GetActiveNeighbours(minutia->position, image);
@@ -146,15 +146,14 @@ static void TraceRidges(List minutiae, BinaryMap * image)
   }
 }
 
-List FindMinutiae(BinaryMap* image, List minutiae)
+void FindMinutiae(BinaryMap* image, List* minutiae)
 {
   minutiaeLocations = UInt8Array2D_Construct(image->width, image->height);
 
-  GetPointsWithNNeighbors(1, image, &minutiae);
-  GetPointsWithNNeighbors(3, image, &minutiae);
+  GetPointsWithNNeighbors(1, image, minutiae);
+  GetPointsWithNNeighbors(3, image, minutiae);
 
   TraceRidges(minutiae, image);
 
   UInt8Array2D_Destruct(&minutiaeLocations);
-  return minutiae;
 }

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -83,16 +83,6 @@ static List GetActiveNeighbours(Point position, BinaryMap * image)
   return neighbors;
 }
 
-static void FreeActiveNeighbours(List *activeNeighbours) 
-{
-  ListElement* cur = activeNeighbours->head;
-  while (cur != NULL) {
-    ListElement* del = cur;
-    cur = cur->next;
-    List_Remove(activeNeighbours,del, NULL);
-  };
-}
-
 static Point * CopyPoint(Point p) {
   Point * pointCopy = calloc(1, sizeof(*pointCopy));
   *pointCopy = p;
@@ -114,6 +104,7 @@ static List TraceRidge(Point point, Point prev, BinaryMap * image, List outputPo
     point = ArePointsEqual(*(Point *)neighbors.head->data, prev) ?
       *(Point *)neighbors.head->next->data : *(Point *)neighbors.head->data;
     prev = point;
+    List_Destroy(&neighbors,&free);
   }
   List_AddData(&outputPoints, CopyPoint(point));
   return outputPoints;
@@ -149,9 +140,10 @@ static void TraceRidges(List minutiae, BinaryMap * image)
       ridge.endMinutia = GetMinutiaAtPosition(*(Point *)(points.tail->data), minutiae);
 
       List_AddData(&minutia->ridges, CopyRidge(ridge));
+      List_Destroy(&points,&free);
     }
     
-    FreeActiveNeighbours(&activeNeighbors);
+    List_Destroy(&activeNeighbors,&free);
   }
 }
 

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -40,7 +40,7 @@ static MinutiaType GetMinutiaType(int numberOfNeighbors) {
   }
 }
 
-static List GetPointsWithNNeighbors(int n, BinaryMap * image, List minutiae)
+static void GetPointsWithNNeighbors(int n, BinaryMap * image, List* minutiae)
 {
   for ( int i=0; i < image->width; ++i ) {
     for ( int j=0; j < image->height; ++j ) {
@@ -48,12 +48,11 @@ static List GetPointsWithNNeighbors(int n, BinaryMap * image, List minutiae)
         Minutia * minutia = calloc(1, sizeof(*minutia));
         minutia->minutiaType = GetMinutiaType(n);
         minutia->position = (Point) { .x = i, .y = j };
-        List_AddData(&minutiae, minutia);
+        List_AddData(minutiae, minutia);
         minutiaeLocations.data[i][j] = minutia->minutiaType;
       }
     }
   }
-  return minutiae;
 }
 
 static List GetActiveNeighbours(Point position, BinaryMap * image)
@@ -151,8 +150,8 @@ List FindMinutiae(BinaryMap* image, List minutiae)
 {
   minutiaeLocations = UInt8Array2D_Construct(image->width, image->height);
 
-  minutiae = GetPointsWithNNeighbors(1, image, minutiae);
-  minutiae = GetPointsWithNNeighbors(3, image, minutiae);
+  GetPointsWithNNeighbors(1, image, &minutiae);
+  GetPointsWithNNeighbors(3, image, &minutiae);
 
   TraceRidges(minutiae, image);
 

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -83,13 +83,14 @@ static List GetActiveNeighburs(Point position, BinaryMap * image)
   return neighbors;
 }
 
-static void FreeActiveNeighbours(List *activeNeighbors) 
+static void FreeActiveNeighbours(List *activeNeighbours) 
 {
-    // Free up the active neighburs list to stop leaking memory...
-    for(ListElement *element = activeNeighbors->head; element != NULL; element = element->next)
-    {
-        List_Remove(activeNeighbors, element, NULL);
-    }
+  ListElement* cur = activeNeighbours->head;
+  while (cur != NULL) {
+    ListElement* del = cur;
+    cur = cur->next;
+    List_Remove(activeNeighbours,del, NULL);
+  };
 }
 
 static Point * CopyPoint(Point p) {

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -71,7 +71,7 @@ static List GetActiveNeighbours(Point position, BinaryMap * image)
       {
         if(BinaryMap_GetBit(image, position.x + i, position.y + j))
         {
-          Point * location = calloc(1, sizeof(*location));
+          Point * location = malloc(sizeof(Point));
           location->x = position.x + i;
           location->y = position.y + j;
 

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -56,7 +56,7 @@ static List GetPointsWithNNeighbors(int n, BinaryMap * image, List minutiae)
   return minutiae;
 }
 
-static List GetActiveNeighburs(Point position, BinaryMap * image)
+static List GetActiveNeighbours(Point position, BinaryMap * image)
 {
   List neighbors = List_Construct();
 
@@ -109,7 +109,7 @@ static List TraceRidge(Point point, Point prev, BinaryMap * image, List outputPo
   List_AddData(&outputPoints, CopyPoint(prev));
   while ( minutiaeLocations.data[point.x][point.y] == None ) {
     List_AddData(&outputPoints, CopyPoint(point));
-    List neighbors = GetActiveNeighburs(point, image);
+    List neighbors = GetActiveNeighbours(point, image);
     assert(List_GetCount(&neighbors) == 2);
     point = ArePointsEqual(*(Point *)neighbors.head->data, prev) ?
       *(Point *)neighbors.head->next->data : *(Point *)neighbors.head->data;
@@ -135,7 +135,7 @@ static void TraceRidges(List minutiae, BinaryMap * image)
   for ( ListElement * p = minutiae.head; p != NULL; p = p->next )
   {
     Minutia * minutia = (Minutia *)p->data;
-    List activeNeighbors = GetActiveNeighburs(minutia->position, image);
+    List activeNeighbors = GetActiveNeighbours(minutia->position, image);
     minutia->ridges = List_Construct();
 
     for ( ListElement * p2 = activeNeighbors.head; p2 != NULL; p2 = p2->next )

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -40,7 +40,7 @@ static MinutiaType GetMinutiaType(int numberOfNeighbors) {
   }
 }
 
-static void GetPointsWithNNeighbors(int n, BinaryMap * image, List* minutiae)
+static void GetPointsWithNNeighbors(int n, BinaryMap* image, List* minutiae)
 {
   for ( int i=0; i < image->width; ++i ) {
     for ( int j=0; j < image->height; ++j ) {
@@ -57,7 +57,7 @@ static void GetPointsWithNNeighbors(int n, BinaryMap * image, List* minutiae)
   }
 }
 
-static List GetActiveNeighbours(Point position, BinaryMap * image)
+static List GetActiveNeighbours(Point position, BinaryMap* image)
 {
   List neighbors = List_Construct();
 
@@ -96,8 +96,9 @@ static Ridge * CopyRidge(Ridge r) {
   return ridgeCopy;
 }
 
-static void TraceRidge(Point point, Point prev, BinaryMap * image, List* outputPoints) {
+static void TraceRidge(Point point, Point prev, BinaryMap* image, List* outputPoints) {
   List_AddData(outputPoints, CopyPoint(prev));
+
   while ( minutiaeLocations.data[point.x][point.y] == None ) {
     List_AddData(outputPoints, CopyPoint(point));
     List neighbors = GetActiveNeighbours(point, image);
@@ -121,7 +122,7 @@ static Minutia * GetMinutiaAtPosition(Point position, List* minutiae)
   return NULL;
 }
 
-static void TraceRidges(List* minutiae, BinaryMap * image)
+static void TraceRidges(List* minutiae, BinaryMap* image)
 {
   for ( ListElement * p = minutiae->head; p != NULL; p = p->next )
   {

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.c
@@ -85,13 +85,13 @@ static List GetActiveNeighbours(Point position, BinaryMap * image)
 }
 
 static Point * CopyPoint(Point p) {
-  Point * pointCopy = calloc(1, sizeof(*pointCopy));
+  Point * pointCopy = malloc(sizeof(Point));
   *pointCopy = p;
   return pointCopy;
 }
 
 static Ridge * CopyRidge(Ridge r) {
-  Ridge * ridgeCopy = calloc(1, sizeof(*ridgeCopy));
+  Ridge * ridgeCopy = malloc(sizeof(Ridge));
   *ridgeCopy = r;
   return ridgeCopy;
 }

--- a/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.h
+++ b/Sources/Extraction/MinutiaeDetection/MinutiaeDetection.h
@@ -4,6 +4,6 @@
 #include "General/BinaryMap.h"
 #include "General/List.h"
 
-List FindMinutiae(BinaryMap* image, List outputMinutiae);
+void FindMinutiae(BinaryMap* image, List* outputMinutiae);
 
 #endif

--- a/Sources/General/List.c
+++ b/Sources/General/List.c
@@ -15,24 +15,24 @@ List List_Construct(void)
 }
 
 void List_Destruct(List* me) {
-  ListElement* temp = me->head;
-  ListElement* cur = me->head;
-  while (cur != NULL) {
-    temp = cur;
-    cur = cur->next;
-    free(temp);
-  };
+    ListElement* temp = me->head;
+    ListElement* cur = me->head;
+    while (cur != NULL) {
+        temp = cur;
+        cur = cur->next;
+        free(temp);
+    };
 }
 
 void List_Destroy(List* me, void (*fr)(void* f)) {
-  ListElement* temp = me->head;
-  ListElement* cur = me->head;
-  while (cur != NULL) {
-    temp = cur;
-    fr(temp->data);
-    cur = cur->next;
-    free(temp);
-  };    
+    ListElement* temp = me->head;
+    ListElement* cur = me->head;
+    while (cur != NULL) {
+        temp = cur;
+        fr(temp->data);
+        cur = cur->next;
+        free(temp);
+    };    
 }
 
 int32_t List_GetCount(List *me)

--- a/Sources/General/List.c
+++ b/Sources/General/List.c
@@ -24,6 +24,17 @@ void List_Destruct(List* me) {
   };
 }
 
+void List_Destroy(List* me, void (*fr)(void* f)) {
+  ListElement* temp = me->head;
+  ListElement* cur = me->head;
+  while (cur != NULL) {
+    temp = cur;
+    fr(temp->data);
+    cur = cur->next;
+    free(temp);
+  };    
+}
+
 int32_t List_GetCount(List *me)
 {
     return me->count;

--- a/Sources/General/List.c
+++ b/Sources/General/List.c
@@ -14,6 +14,16 @@ List List_Construct(void)
     return list;
 }
 
+void List_Destruct(List* me) {
+  ListElement* temp = me->head;
+  ListElement* cur = me->head;
+  while (cur != NULL) {
+    temp = cur;
+    cur = cur->next;
+    free(temp);
+  };
+}
+
 int32_t List_GetCount(List *me)
 {
     return me->count;

--- a/Sources/General/List.h
+++ b/Sources/General/List.h
@@ -22,6 +22,9 @@ List List_Construct(void);
 
 // Note that this only destructs the list structure - NOT the data contained within
 void List_Destruct(List* me);
+
+// Destroy the elements and the list using the supplied free function
+void List_Destroy(List* me, void (*fr)(void* f));
 int32_t List_GetCount(List *me);
 int32_t List_Remove(List *me, ListElement *item, void **data);
 

--- a/Sources/General/List.h
+++ b/Sources/General/List.h
@@ -19,6 +19,9 @@ typedef struct List
 } List;
 
 List List_Construct(void);
+
+// Note that this only destructs the list structure - NOT the data contained within
+void List_Destruct(List* me);
 int32_t List_GetCount(List *me);
 int32_t List_Remove(List *me, ListElement *item, void **data);
 

--- a/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
+++ b/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
@@ -17,15 +17,6 @@ TEST_TEAR_DOWN(HillOrientation)
 {
 }
 
-static void print_orientations(UInt16Array2D orientations) {
-  for ( int i=0; i < orientations.sizeX; ++i ) {
-    for ( int j=0; j < orientations.sizeY; ++j ) {
-      printf("%d ", orientations.data[i][j]);
-    }
-    printf("\n");
-  }
-}
-
 TEST(HillOrientation, VisualiseOrientations)
 {
   UInt8Array2D v = pgm_read("../TestImages/Person1/Bas1440999265-Hamster-1-0.png.pgm");
@@ -51,7 +42,6 @@ TEST(HillOrientation, VisualiseOrientations)
   UInt16Array2D orientations = UInt16Array2D_Construct(blocks.blockCount.width, blocks.blockCount.height); 
   HillOrientation_Detect(equalized, imgSize, &mask, &blocks, &orientations);
 
-  print_orientations(orientations);
   UInt8Array2D outV = UInt8Array2D_Construct(imgSize.width, imgSize.height);
   for ( int i=0; i < orientations.sizeX; ++i ) {
     for ( int j=0; j < orientations.sizeY; ++j ) {
@@ -103,6 +93,15 @@ TEST(HillOrientation, VisualiseOrientations)
     }
   }
   pgm_write("../TestImages/Person1/output-Hamster-1-0.pgm", &outV);
+
+  UInt8Array2D_Destruct(&v);
+  BlockMap_Destruct(&blocks);
+  Int16Array3D_Destruct(&histogram);
+  Int16Array3D_Destruct(&smoothedHistogram);
+  BinaryMap_Destruct(&mask);
+  FloatArray2D_Destruct(&equalized);
+  UInt16Array2D_Destruct(&orientations);
+  UInt8Array2D_Destruct(&outV);
 }
 
 TEST(HillOrientation, VisualisePixelMask)
@@ -132,6 +131,14 @@ TEST(HillOrientation, VisualisePixelMask)
     }
   }
   pgm_write("../TestImages/Person1/output-Hamster-0.1-pixelmask.pgm", &outV);
+
+  UInt8Array2D_Destruct(&v);
+  BlockMap_Destruct(&blocks);
+  Int16Array3D_Destruct(&histogram);
+  Int16Array3D_Destruct(&smoothedHistogram);
+  BinaryMap_Destruct(&mask);
+  BoolArray2D_Destruct(&pixelMask);
+  UInt8Array2D_Destruct(&outV);;
 }
 
 TEST(HillOrientation, ComputeOrientations) 
@@ -181,4 +188,12 @@ TEST(HillOrientation, ComputeOrientations)
     TEST_ASSERT_EQUAL_INT_MESSAGE(128, orientations.data[1][0], "Failed at: 1,0");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, orientations.data[1][1], "Failed at: 1,1");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, orientations.data[1][2], "Failed at: 1,2");
+
+    // TODO free all the things
+    BlockMap_Destruct(&blocks);
+    FloatArray2D_Destruct(&equalized);
+    BinaryMap_Destruct(&mask);
+    Int16Array3D_Destruct(&histogram);
+    Int16Array3D_Destruct(&smoothedHistogram);
+    UInt16Array2D_Destruct(&orientations);
 }

--- a/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
+++ b/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
@@ -196,4 +196,5 @@ TEST(HillOrientation, ComputeOrientations)
     Int16Array3D_Destruct(&histogram);
     Int16Array3D_Destruct(&smoothedHistogram);
     UInt16Array2D_Destruct(&orientations);
+    Equalizer_Destruct(&eq);
 }

--- a/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
+++ b/Sources/Tests/Extraction/Filters/Test_HillOrientation.c
@@ -102,6 +102,7 @@ TEST(HillOrientation, VisualiseOrientations)
   FloatArray2D_Destruct(&equalized);
   UInt16Array2D_Destruct(&orientations);
   UInt8Array2D_Destruct(&outV);
+  Equalizer_Destruct(&eq);
 }
 
 TEST(HillOrientation, VisualisePixelMask)
@@ -189,7 +190,7 @@ TEST(HillOrientation, ComputeOrientations)
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, orientations.data[1][1], "Failed at: 1,1");
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, orientations.data[1][2], "Failed at: 1,2");
 
-    // TODO free all the things
+    UInt8Array2D_Destruct(&v);
     BlockMap_Destruct(&blocks);
     FloatArray2D_Destruct(&equalized);
     BinaryMap_Destruct(&mask);

--- a/Sources/Tests/Extraction/Filters/Test_OrientedSmoother.c
+++ b/Sources/Tests/Extraction/Filters/Test_OrientedSmoother.c
@@ -82,6 +82,16 @@ TEST(OrientedSmoother, CalculationsMatchSourceAFISOn7x9) {
              TEST_ASSERT_MESSAGE(fabs(expected[i][j] - orthogonalImage.data[i][j]) < EPSILON, assertMessage);
         }
     }
+
+    //
+    UInt8Array2D_Destruct(&v);
+    BlockMap_Destruct(&blocks);
+    Int16Array3D_Destruct(&histogram);
+    Int16Array3D_Destruct(&smoothedHistogram);
+    BinaryMap_Destruct(&mask);
+    FloatArray2D_Destruct(&equalized);
+    UInt16Array2D_Destruct(&orientations);
+    FloatArray2D_Destruct(&orthogonalImage);
 }
 
 TEST(OrientedSmoother, VisualiseSmoother)

--- a/Sources/Tests/Extraction/Filters/Test_OrientedSmoother.c
+++ b/Sources/Tests/Extraction/Filters/Test_OrientedSmoother.c
@@ -92,6 +92,7 @@ TEST(OrientedSmoother, CalculationsMatchSourceAFISOn7x9) {
     FloatArray2D_Destruct(&equalized);
     UInt16Array2D_Destruct(&orientations);
     FloatArray2D_Destruct(&orthogonalImage);
+    Equalizer_Destruct(&eq);
 }
 
 TEST(OrientedSmoother, VisualiseSmoother)
@@ -171,4 +172,5 @@ TEST(OrientedSmoother, VisualiseSmoother)
   FloatArray2D_Destruct(&orthogonalImage);
   BinaryMap_Destruct(&binarized);
   UInt8Array2D_Destruct(&newV);
+  Equalizer_Destruct(&eq);
 }

--- a/Sources/Tests/Extraction/Filters/Test_OrientedSmoother.c
+++ b/Sources/Tests/Extraction/Filters/Test_OrientedSmoother.c
@@ -156,4 +156,19 @@ TEST(OrientedSmoother, VisualiseSmoother)
   BinaryMapToImage(&binarized, &newV);
 
   pgm_write("../TestImages/Person1/output-binarised-Hamster-1.0.pgm", &newV);
+
+  UInt8Array2D_Destruct(&v);
+  BlockMap_Destruct(&blocks);
+
+  Int16Array3D_Destruct(&histogram);
+  Int16Array3D_Destruct(&smoothedHistogram);
+
+  BinaryMap_Destruct(&mask);
+  FloatArray2D_Destruct(&equalized);
+  UInt16Array2D_Destruct(&orientations);
+  FloatArray2D_Destruct(&smoothedImage);
+
+  FloatArray2D_Destruct(&orthogonalImage);
+  BinaryMap_Destruct(&binarized);
+  UInt8Array2D_Destruct(&newV);
 }

--- a/Sources/Tests/Extraction/Model/Test_DotRemover.c
+++ b/Sources/Tests/Extraction/Model/Test_DotRemover.c
@@ -45,4 +45,6 @@ TEST(DotRemover, DotRemover_Filter_correct_minutia_is_removed)
     Minutia *remainingMinutia = (Minutia *) minutiae.head->data;
 
     TEST_ASSERT_EQUAL_INT(1, remainingMinutia->position.x);
+
+    List_Destruct(&minutiae);
 }

--- a/Sources/Tests/Extraction/Model/Test_DotRemover.c
+++ b/Sources/Tests/Extraction/Model/Test_DotRemover.c
@@ -46,5 +46,6 @@ TEST(DotRemover, DotRemover_Filter_correct_minutia_is_removed)
 
     TEST_ASSERT_EQUAL_INT(1, remainingMinutia->position.x);
 
+    List_Destruct(&ridges);
     List_Destruct(&minutiae);
 }

--- a/Sources/Tests/General/Test_MinutiaeDetection.c
+++ b/Sources/Tests/General/Test_MinutiaeDetection.c
@@ -123,8 +123,8 @@ TEST(MinutiaeDetection, CanCountMinutiaeRidges)
   TEST_ASSERT_EQUAL_INT(1, firstMinutiaRidgeCount);
   TEST_ASSERT_EQUAL_INT(1, secondMinutiaRidgeCount);
 
-  List_Destruct(&minutiae);
   BinaryMap_Destruct(&BinarizedThinnedImage);
+  List_Destruct(&minutiae);
 }
 
 TEST(MinutiaeDetection, CanCountBifurcationRidges)

--- a/Sources/Tests/General/Test_MinutiaeDetection.c
+++ b/Sources/Tests/General/Test_MinutiaeDetection.c
@@ -65,6 +65,9 @@ TEST(MinutiaeDetection, CanDetectARidgeEnding)
   TEST_ASSERT_EQUAL_INT(RidgeEnd, firstMinutia->minutiaType);
   TEST_ASSERT_EQUAL_INT(2, secondMinutia->position.x);
   TEST_ASSERT_EQUAL_INT(1, secondMinutia->position.y);
+
+  BinaryMap_Destruct(&BinarizedThinnedImage);
+  List_Destruct(&result);
 }
 
 TEST(MinutiaeDetection, CanDetectABifurcation)
@@ -91,6 +94,9 @@ TEST(MinutiaeDetection, CanDetectABifurcation)
   TEST_ASSERT_EQUAL_INT(Bifurcation, minutia->minutiaType);
   TEST_ASSERT_EQUAL_INT(2, minutia->position.x);
   TEST_ASSERT_EQUAL_INT(2, minutia->position.y);
+
+  BinaryMap_Destruct(&BinarizedThinnedImage);
+  List_Destruct(&result);  
 }
 
 TEST(MinutiaeDetection, CanCountMinutiaeRidges)
@@ -117,6 +123,9 @@ TEST(MinutiaeDetection, CanCountMinutiaeRidges)
 
   TEST_ASSERT_EQUAL_INT(1, firstMinutiaRidgeCount);
   TEST_ASSERT_EQUAL_INT(1, secondMinutiaRidgeCount);
+
+  BinaryMap_Destruct(&BinarizedThinnedImage);
+  List_Destruct(&minutiae);
 }
 
 TEST(MinutiaeDetection, CanCountBifurcationRidges)
@@ -156,4 +165,7 @@ TEST(MinutiaeDetection, CanCountBifurcationRidges)
 
   TEST_ASSERT_EQUAL_INT(RidgeEnd, minutia31->minutiaType);
   TEST_ASSERT_EQUAL_INT(1, List_GetCount(&minutia31->ridges));
+
+  List_Destruct(&minutiae);
+  BinaryMap_Destruct(&BinarizedThinnedImage);
 }

--- a/Sources/Tests/General/Test_MinutiaeDetection.c
+++ b/Sources/Tests/General/Test_MinutiaeDetection.c
@@ -50,8 +50,7 @@ TEST(MinutiaeDetection, CanDetectARidgeEnding)
 
   BinaryMap BinarizedThinnedImage = MakeBinaryMap(4, 4, data);
   List result = List_Construct();
-
-  result = FindMinutiae(&BinarizedThinnedImage, result);
+  FindMinutiae(&BinarizedThinnedImage, &result);
 
   TEST_ASSERT_EQUAL_INT(2, List_GetCount(&result));
 
@@ -82,7 +81,7 @@ TEST(MinutiaeDetection, CanDetectABifurcation)
   BinaryMap BinarizedThinnedImage = MakeBinaryMap(4, 4, data);
   List result = List_Construct();
 
-  result = FindMinutiae(&BinarizedThinnedImage, result);
+  FindMinutiae(&BinarizedThinnedImage, &result);
 
   Minutia * minutia;
   for ( ListElement * p = result.head; p != NULL; p = p->next ) {
@@ -112,7 +111,7 @@ TEST(MinutiaeDetection, CanCountMinutiaeRidges)
   BinaryMap BinarizedThinnedImage = MakeBinaryMap(5, 5, data);
   List minutiae = List_Construct();
 
-  minutiae = FindMinutiae(&BinarizedThinnedImage, minutiae);
+  FindMinutiae(&BinarizedThinnedImage, &minutiae);
 
   TEST_ASSERT_EQUAL_INT(2, List_GetCount(&minutiae));
 
@@ -142,7 +141,7 @@ TEST(MinutiaeDetection, CanCountBifurcationRidges)
   BinaryMap BinarizedThinnedImage = MakeBinaryMap(5, 6, data);
   List minutiae = List_Construct();
 
-  minutiae = FindMinutiae(&BinarizedThinnedImage, minutiae);
+  FindMinutiae(&BinarizedThinnedImage, &minutiae);
 
   TEST_ASSERT_EQUAL_INT(4, List_GetCount(&minutiae));
 

--- a/Sources/Tests/General/Test_MinutiaeDetection.c
+++ b/Sources/Tests/General/Test_MinutiaeDetection.c
@@ -96,7 +96,7 @@ TEST(MinutiaeDetection, CanDetectABifurcation)
   TEST_ASSERT_EQUAL_INT(2, minutia->position.y);
 
   BinaryMap_Destruct(&BinarizedThinnedImage);
-  List_Destruct(&result);  
+  List_Destruct(&result);
 }
 
 TEST(MinutiaeDetection, CanCountMinutiaeRidges)
@@ -124,8 +124,8 @@ TEST(MinutiaeDetection, CanCountMinutiaeRidges)
   TEST_ASSERT_EQUAL_INT(1, firstMinutiaRidgeCount);
   TEST_ASSERT_EQUAL_INT(1, secondMinutiaRidgeCount);
 
-  BinaryMap_Destruct(&BinarizedThinnedImage);
   List_Destruct(&minutiae);
+  BinaryMap_Destruct(&BinarizedThinnedImage);
 }
 
 TEST(MinutiaeDetection, CanCountBifurcationRidges)

--- a/Sources/Tests/extract.c
+++ b/Sources/Tests/extract.c
@@ -59,6 +59,10 @@ int main(int argc, char* argv[])
         strcpy(thinnedFilename, filename);
         strcpy(thinnedFilename + filenameLen - 4, ".thinned.pgm");
         pgm_write(thinnedFilename, &thinnedImage);
+
+        UInt8Array2D_Destruct(&image);
+        UInt8Array2D_Destruct(&binarizedImage);
+        UInt8Array2D_Destruct(&thinnedImage);
     }
 
     return 0;


### PR DESCRIPTION
I spent a few minutes tackling the memory leaks reported by valgrind.  This should also fix the random Mac crash (see 427e999).

This may duplicate some of @adkgit work on the fix_tests_memory branch, but I didn't see that until I opened this pull request.  My bad :-1: 

There's still a nasty leak in `MinutiaDetection`.  I'm unable to get to the bottom of it, but it's something to do with pointers being shared across two structures.
